### PR TITLE
When $archive changed, the old archives isn't deleted.

### DIFF
--- a/src/ganglia/cron.weekly/ganglia-save-rrds.cron
+++ b/src/ganglia/cron.weekly/ganglia-save-rrds.cron
@@ -135,7 +135,7 @@ tar cPf $archive/ganglia-rrds.$date.tar /var/lib/ganglia/rrds
 
 # Keep only the three most recent archives
 # Assumes that only archives are in this directory.
-removeme=`ls -t /var/lib/ganglia/archives | tail -n +4`
+removeme=`ls -t $archive | tail -n +4`
 for a in $removeme
 do
 	rm -f $archive/$a


### PR DESCRIPTION
This directory name for archive is set to $archive, but use the hard-coded path for $removeme listing.
